### PR TITLE
Don't rely on the order of stanzas

### DIFF
--- a/t/basic.t
+++ b/t/basic.t
@@ -40,7 +40,7 @@ is_deeply(\%{$cfg->get_block('db')},
     &cfg_get_block,
     '->get_block returns expected data structure' );
 
-is_deeply( Config::Simple::Extended::get_stanzas( $cfg ),
+is_deeply( { map{ $_ => 1 }@{ Config::Simple::Extended::get_stanzas( $cfg ) },
     &cfg_get_stanzas,
     'Config::Simple::Extended::get_stanzas returns expected data structure' );
 
@@ -51,7 +51,7 @@ note &Mojolicious::Plugin::ConfigSimple::version;
 done_testing();
 
 sub cfg_get_stanzas {
-  return [ qw( db default ) ];
+  return { db => 1, default => 1 };
 }
 
 sub cfg_get_block {


### PR DESCRIPTION
Config::Simple::Extended uses a hash to get unique stanzas. You shouldn't rely on the order of that has. Especially since Perl 5.18 added more randomness to key order in hashes.

Maybe Config::Simple::Extended can use a `sort` to return reliably ordered stanzas.
